### PR TITLE
Check template should catch only TCLResult

### DIFF
--- a/src/opencl.nim
+++ b/src/opencl.nim
@@ -188,9 +188,8 @@ type
 proc raiseEOpenCL*(x: TClResult) {.noinline.} =
   raise newException(EOpenCL, $x & " " & $int(x))
 
-template check*(a: expr) =
-  let y = a
-  if y != TClResult.Success: raiseEOpenCL(y)
+template check*(a: TClResult) =
+  if a != TClResult.Success: raiseEOpenCL(a)
 
 #  OpenCL Version 
 


### PR DESCRIPTION
Currently ``check`` template catches any expression so when importing OpenCL, you cannot use check anywhere else in your code.

This makes opencl incompatible with NimCuda for example: https://github.com/unicredit/nimcuda/blob/5ca0cbcd962050e522f7ad01de0a8ba585a61eaa/nimcuda/nimcuda.nim#L47-L81
Or CLBlast: https://github.com/numforge/nim-clblast/blob/master/src/clblast.nim#L12-L15.

I suppose several other C library wrappers have a template called "check" to test the return status/error code.