### PR TITLE
push version v1.1

### DIFF
--- a/opencl.nimble
+++ b/opencl.nimble
@@ -1,6 +1,6 @@
 [Package]
 name: "opencl"
-version: "1.0"
+version: "1.1"
 author: "Andreas Rumpf"
 description: "Low-level wrapper for OpenCL"
 license: "MIT"


### PR DESCRIPTION
The last patch by @andreaferretti was not accompanied by a new release
and tag.

This had the effect that nimble thought "oh it's fine, 1.0 is installed", but that left me with the previous version without the patch. Please merge this or just create push a similar update to `master` and also push a new tag for the new version! 